### PR TITLE
Fixed the kcalcore dependency. Modified the location of the temporary

### DIFF
--- a/clientplugins/syncmlclient/BTConnection.cpp
+++ b/clientplugins/syncmlclient/BTConnection.cpp
@@ -38,9 +38,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <termios.h>
-#include <libsynccommon/SyncDBusConnection.h>
-
-#include "LogMacros.h"
+#include <buteosyncfw/SyncDBusConnection.h>
+#include <buteosyncfw/LogMacros.h>
 
 #define BLUEZ_DEST "org.bluez"
 #define BLUEZ_MANAGER_INTERFACE "org.bluez.Manager"

--- a/clientplugins/syncmlclient/BTConnection.h
+++ b/clientplugins/syncmlclient/BTConnection.h
@@ -35,7 +35,7 @@
 
 #include <QString>
 
-#include <libmeegosyncml/OBEXConnection.h>
+#include <buteosyncml/OBEXConnection.h>
 
 /*! \brief Class for creating a connection to another device over
  *         Bluetooth for libmeegosyncml

--- a/clientplugins/syncmlclient/SyncMLClient.cpp
+++ b/clientplugins/syncmlclient/SyncMLClient.cpp
@@ -26,22 +26,22 @@
 #include <QLibrary>
 #include <QtNetwork>
 
-#include <libsyncpluginmgr/PluginCbInterface.h>
-#include <libmeegosyncml/SyncAgent.h>
-#include <libmeegosyncml/SyncAgentConfig.h>
-#include <libmeegosyncml/SyncAgentConfigProperties.h>
-#include <libmeegosyncml/HTTPTransport.h>
-#include <libmeegosyncml/OBEXTransport.h>
-#include <libmeegosyncml/DeviceInfo.h>
+#include <buteosyncfw/PluginCbInterface.h>
+#include <buteosyncml/SyncAgent.h>
+#include <buteosyncml/SyncAgentConfig.h>
+#include <buteosyncml/SyncAgentConfigProperties.h>
+#include <buteosyncml/HTTPTransport.h>
+#include <buteosyncml/OBEXTransport.h>
+#include <buteosyncml/DeviceInfo.h>
 
 #include "SyncMLConfig.h"
 #include "SyncMLCommon.h"
 #include "DeviceInfo.h"
 
-#include <LogMacros.h>
+#include <buteosyncfw/LogMacros.h>
 
-const QString DEFAULTCONFIGFILE("/etc/sync/meego-syncml-conf.xml");
-const QString EXTCONFIGFILE("/etc/sync/ext-syncml-conf.xml");
+const QString DEFAULTCONFIGFILE("/etc/buteo/meego-syncml-conf.xml");
+const QString EXTCONFIGFILE("/etc/buteo/ext-syncml-conf.xml");
 
 extern "C" SyncMLClient* createPlugin(const QString& aPluginName,
 		const Buteo::SyncProfile& aProfile,

--- a/clientplugins/syncmlclient/SyncMLClient.h
+++ b/clientplugins/syncmlclient/SyncMLClient.h
@@ -26,9 +26,9 @@
 
 #include "BTConnection.h"
 #include "SyncMLStorageProvider.h"
-#include <libsyncpluginmgr/ClientPlugin.h>
-#include <libsyncprofile/SyncResults.h>
-#include <libmeegosyncml/SyncAgent.h>
+#include <ClientPlugin.h>
+#include <SyncResults.h>
+#include <buteosyncml/SyncAgent.h>
 
 namespace DataSync {
 

--- a/clientplugins/syncmlclient/syncmlclient.pro
+++ b/clientplugins/syncmlclient/syncmlclient.pro
@@ -1,18 +1,20 @@
 TEMPLATE = lib
 TARGET = syncml-client
 DEPENDPATH += . 
-INCLUDEPATH += . ../../syncmlcommon \
-    /usr/include/libsynccommon \
-    /usr/include/libsyncprofile \
-    /usr/include/sync \
+INCLUDEPATH += . ../../syncmlcommon
 
-LIBS += -L../../syncmlcommon -lsyncpluginmgr -lsyncprofile -lmeegosyncml -lsyncmlcommon
+LIBS += -L../../syncmlcommon -lsyncmlcommon
 
-CONFIG += plugin mobility
+CONFIG += link_pkgconfig plugin mobility
+PKGCONFIG += buteosyncfw buteosyncml
 
 MOBILITY += systeminfo
 QT += dbus sql network
 QT -= gui
+
+VER_MAJ = 1
+VER_MIN = 0
+VER_PAT = 0
 
 #input
 HEADERS += SyncMLClient.h BTConnection.h
@@ -33,20 +35,20 @@ QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno $(OBJECTS_DIR)/*.gcov
 
 
 #install
-target.path = /usr/lib/sync/
+target.path = /usr/lib/buteo-plugins
 
-client.path = /etc/sync/profiles/client 
+client.path = /etc/buteo/profiles/client 
 client.files = xml/syncml.xml
 
 ####To Remove Later After Accounts Integration
 
-sync.path = /etc/sync/profiles/sync
+sync.path = /etc/buteo/profiles/sync
 sync.files = xml/sync/*
 
-service.path = /etc/sync/profiles/service
-service.files = xml/service/*
+#service.path = /etc/buteo/profiles/service
+#service.files = xml/service/*
 
-storage.path = /etc/sync/profiles/storage
+storage.path = /etc/buteo/profiles/storage
 storage.files = xml/storage/*
 
 INSTALLS += target client sync service storage 

--- a/clientplugins/syncmlclient/xml/sync/memotoo.com.xml
+++ b/clientplugins/syncmlclient/xml/sync/memotoo.com.xml
@@ -1,26 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <profile name="memotoo.com" type="sync" >
+    <key name="Remote database" value="http://sync.memotoo.com/syncml" />
 
-<key name="displayname" value="Memotoo"/>
+    <key name="Username" value="" />
+    <key name="Password" value="" />
+    <key name="destinationtype" value="online"/>
+    <key name="displayname" value="Memotoo"/>
     <key name="enabled" value="true" />
     <key name="use_accounts" value="false" />
     <key name="hidden" value="true" />
 
-    <profile type="service" name="memotoo.com" >
+    <profile name="syncml" type="client" >
+        <key name="use_wbxml" value="false" />
+        <key name="Sync Transport" value="HTTP" />
+        <key name="Sync Direction" value="two-way" />
+        <key name="Sync Protocol" value="SyncML12" />
     </profile>
 
     <profile name="hcontacts" type="storage" >
         <key name="enabled" value="true" />
+        <key name="Local URI" value="./contacts" />
+        <key name="Target URI" value="contact" />
     </profile>
 
     <profile name="hcalendar" type="storage" >
         <key name="enabled" value="true" />
         <key name="Notebook Name" value="Personal"/>
+        <key name="Local URI" value="./calendar" />
+        <key name="Target URI" value="caltask" />
+        <key name="Calendar Format" value="vcalendar" />
     </profile>
 
     <profile name="hnotes" type="storage" >
         <key name="enabled" value="true" />
+        <key name="Local URI" value="./Notepad" />
+        <key name="Target URI" value="note" />
     </profile>
 </profile>
 

--- a/storagechangenotifierplugins/hcontacts/hcontacts.pro
+++ b/storagechangenotifierplugins/hcontacts/hcontacts.pro
@@ -2,12 +2,15 @@ TEMPLATE = lib
 TARGET = hcontacts-changenotifier
 
 DEPENDPATH += .
-INCLUDEPATH += . \
-               /usr/include/libsyncpluginmgr
 
-CONFIG += plugin mobility link_pkgconfig
+CONFIG += link_pkgconfig plugin mobility link_pkgconfig
+PKGCONFIG += buteosyncfw
+
 MOBILITY += contacts
-PKGCONFIG = synccommon
+
+VER_MAJ = 1
+VER_MIN = 0
+VER_PAT = 0
  
 QT -= GUI
 
@@ -24,5 +27,5 @@ QMAKE_CXXFLAGS = -Wall \
 
 QMAKE_CLEAN += $(TARGET)
 
-target.path = /usr/lib/sync/
+target.path = /usr/lib/buteo-plugins
 INSTALLS += target

--- a/storageplugins/hcalendar/CalendarStorage.h
+++ b/storageplugins/hcalendar/CalendarStorage.h
@@ -23,8 +23,8 @@
 #ifndef CALENDARSTORAGE_H
 #define CALENDARSTORAGE_H
 
-#include <libsyncpluginmgr/StoragePlugin.h>
-#include <libsyncprofile/ProfileEngineDefs.h>
+#include <buteosyncfw/StoragePlugin.h>
+#include <buteosyncfw/ProfileEngineDefs.h>
 
 //sync backend related includes
 #include "definitions.h"

--- a/storageplugins/hcalendar/hcalendar.pro
+++ b/storageplugins/hcalendar/hcalendar.pro
@@ -3,17 +3,19 @@ TARGET = hcalendar-storage
 DEPENDPATH += . \
               
 INCLUDEPATH += . \
-    /usr/include/libsyncpluginmgr \
-    /usr/include/libsynccommon \
-    /usr/include/sync \
     ../../syncmlcommon
 		
 		
-CONFIG += plugin kcalcoren mkcal
+CONFIG += link_pkgconfig plugin kcalcore mkcal
+PKGCONFIG += buteosyncfw
+
+VER_MAJ = 1
+VER_MIN = 0
+VER_PAT = 0
 
 QT -= gui
 
-LIBS += -L../../syncmlcommon -lsyncmlcommon -lsyncpluginmgr
+LIBS += -L../../syncmlcommon -lsyncmlcommon
 
 HEADERS += CalendarStorage.h \
            definitions.h \
@@ -30,9 +32,9 @@ QMAKE_CXXFLAGS = -Wall \
 
 QMAKE_CLEAN += $(TARGET) $(TARGET0) $(TARGET1) $(TARGET2)
 
-target.path = /usr/lib/sync/
+target.path = /usr/lib/buteo-plugins
 
-ctcaps.path =/etc/sync/xml/
+ctcaps.path =/etc/buteo/xml/
 ctcaps.files=xml/CTCaps_calendar_11.xml xml/CTCaps_calendar_12.xml
 
 INSTALLS += target ctcaps

--- a/storageplugins/hcontacts/ContactsBackend.cpp
+++ b/storageplugins/hcontacts/ContactsBackend.cpp
@@ -53,12 +53,12 @@ bool ContactsBackend::init()
 	bool initStatus = false;
 	QStringList availableManagers = QContactManager::availableManagers();
 
-	if(availableManagers.contains("tracker")) {
+    if(availableManagers.contains(QLatin1String("tracker"))) {
 		// hardcode to tracker
 		LOG_DEBUG("connecting to storage tracker");
         QMap<QString,QString> params;
-        params.insert("contact-types", QContactType::TypeContact);
-        iMgr = new QContactManager("tracker", params);
+        params.insert(QLatin1String("contact-types"), QContactType::TypeContact);
+        iMgr = new QContactManager(QLatin1String("tracker"), params);
 
 		if(iMgr != NULL){
 			initStatus = true;
@@ -97,8 +97,7 @@ QList<QContactLocalId> ContactsBackend::getAllContactIds()
 
     if (iMgr != NULL) {
         contactIDs = iMgr->contactIds(getSyncTargetFilter());
-    }
-    else {
+    } else {
         LOG_WARNING("Contacts backend not available");
     }
     

--- a/storageplugins/hcontacts/ContactsStorage.h
+++ b/storageplugins/hcontacts/ContactsStorage.h
@@ -28,7 +28,7 @@
 
 #include "StoragePlugin.h"
 #include "ContactsBackend.h"
-#include "libsyncpluginmgr/DeletedItemsIdStorage.h"
+#include "buteosyncfw/DeletedItemsIdStorage.h"
 
 class SimpleItem;
 

--- a/storageplugins/hcontacts/hcontacts.pro
+++ b/storageplugins/hcontacts/hcontacts.pro
@@ -13,12 +13,15 @@ linux-g++-maemo {
 
 DEPENDPATH += .
 INCLUDEPATH += .  \
-    /usr/include/libsynccommon \
-    /usr/include/libsyncpluginmgr \
-    /usr/include/sync/ \
     ../../syncmlcommon
 
-CONFIG += plugin mobility
+CONFIG += link_pkgconfig plugin mobility
+PKGCONFIG += buteosyncfw
+
+VER_MAJ = 1
+VER_MIN = 0
+VER_PAT = 0
+
 MOBILITY += contacts versit   
  
 #the contacts library is using QPixmap, so has to comment below line
@@ -39,12 +42,12 @@ QMAKE_CXXFLAGS = -Wall \
     -Wno-cast-align \
     -O2 -finline-functions
 
-LIBS += -L../../syncmlcommon -lsyncmlcommon -lsyncpluginmgr
+LIBS += -L../../syncmlcommon -lsyncmlcommon
 
 QMAKE_CLEAN += $(TARGET) $(TARGET0) $(TARGET1) $(TARGET2)
-target.path = /usr/lib/sync/
+target.path = /usr/lib/buteo-plugins
 
-ctcaps.path =/etc/sync/xml/
+ctcaps.path =/etc/buteo/xml/
 ctcaps.files=xml/CTCaps_contacts_11.xml xml/CTCaps_contacts_12.xml
 
 INSTALLS += target ctcaps

--- a/storageplugins/hcontacts/unittest/unittest.pro
+++ b/storageplugins/hcontacts/unittest/unittest.pro
@@ -2,7 +2,8 @@ TEMPLATE = app
 TARGET = hcontacts-tests 
  
 QT += core testlib sql
-CONFIG += qtestlib mobility
+CONFIG += link_pkgconfig qtestlib mobility
+PKGCONFIG = buteosyncfw
 
 DEPENDPATH += . \
               ../ \
@@ -20,9 +21,6 @@ linux-g++-maemo {
               
 INCLUDEPATH += . \
     ../ \
-    /usr/include/libsynccommon \
-    /usr/include/libsyncpluginmgr \
-    /usr/include/sync \
     ../../../syncmlcommon
 
 MOBILITY += contacts versit    
@@ -38,7 +36,7 @@ SOURCES += main.cpp \
            ContactDetailHandler.cpp
 
 LIBS += -L ../
-LIBS += -lQtTest -lsynccommon -lsyncpluginmgr -lsyncprofile
+LIBS += -lQtTest
 
 
 QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno

--- a/storageplugins/hnotes/NotesStorage.cpp
+++ b/storageplugins/hnotes/NotesStorage.cpp
@@ -26,7 +26,7 @@
 #include <QFile>
 #include <QStringListIterator>
 
-#include <libsyncpluginmgr/StorageItem.h>
+#include <buteosyncfw/StorageItem.h>
 
 #include <LogMacros.h>
 

--- a/storageplugins/hnotes/NotesStorage.h
+++ b/storageplugins/hnotes/NotesStorage.h
@@ -24,8 +24,8 @@
 #define NOTESSTORAGE_H
 
 
-#include <libsyncpluginmgr/StoragePlugin.h>
-#include <libsyncprofile/ProfileEngineDefs.h>
+#include <buteosyncfw/StoragePlugin.h>
+#include <buteosyncfw/ProfileEngineDefs.h>
 
 #include "NotesBackend.h"
 

--- a/storageplugins/hnotes/hnotes.pro
+++ b/storageplugins/hnotes/hnotes.pro
@@ -1,13 +1,16 @@
 TEMPLATE = lib
 TARGET = hnotes-storage
 DEPENDPATH += .
-INCLUDEPATH += . ../../syncmlcommon \
-    /usr/include/libsynccommon \
-    /usr/include/sync 
+INCLUDEPATH += . ../../syncmlcommon
 
-LIBS += -L../../syncmlcommon -lsyncmlcommon -lsyncpluginmgr
+LIBS += -L../../syncmlcommon -lsyncmlcommon
 
-CONFIG += plugin kcalcoren mkcal
+CONFIG += link_pkgconfig plugin kcalcoren mkcal
+PKGCONFIG += buteosyncfw
+
+VER_MAJ = 1
+VER_MIN = 0
+VER_PAT = 0
 
 QT -= gui
 
@@ -29,9 +32,9 @@ QMAKE_CLEAN += $(TARGET) $(TARGET0) $(TARGET1) $(TARGET2)
 QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno $(OBJECTS_DIR)/*.gcov $(OBJECTS_DIR)/moc_*
 
 #install
-target.path = /usr/lib/sync/
+target.path = /usr/lib/buteo-plugins
 
-ctcaps.path =/etc/sync/xml/
+ctcaps.path =/etc/buteo/xml/
 ctcaps.files=xml/CTCaps_notes_11.xml xml/CTCaps_notes_12.xml
 
 INSTALLS += target ctcaps

--- a/storageplugins/hnotes/unittest/unittest.pro
+++ b/storageplugins/hnotes/unittest/unittest.pro
@@ -33,10 +33,8 @@ INCLUDEPATH += . \
     /usr/include/libsynccommon \
     /usr/include/mkcal
 
-LIBS += -lsyncpluginmgr -lsyncprofile -lQtTest -lsynccommon \
+LIBS += -lQtTest
 
-#   -lsynccommon
-               
 HEADERS += NotesTest.h \
            NotesStorage.h \
            NotesBackend.h \
@@ -54,7 +52,8 @@ SOURCES += main.cpp \
 
 QT += testlib
 QT -= gui
-CONFIG += qtestlib kcalcoren mkcal
+CONFIG += qtestlib kcalcoren mkcal link_pkgconfig
+PKGCONFIG = buteosyncfw
 
 QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno
 QMAKE_CXXFLAGS += -fprofile-arcs -ftest-coverage

--- a/syncmlcommon/ItemAdapter.cpp
+++ b/syncmlcommon/ItemAdapter.cpp
@@ -23,7 +23,7 @@
 
 #include "ItemAdapter.h"
 
-#include <libsyncpluginmgr/StorageItem.h>
+#include <buteosyncfw/StorageItem.h>
 
 ItemAdapter::ItemAdapter( Buteo::StorageItem* aItem ) : iItem( aItem )
 {

--- a/syncmlcommon/ItemAdapter.h
+++ b/syncmlcommon/ItemAdapter.h
@@ -24,7 +24,7 @@
 #ifndef ITEMADAPTER_H
 #define ITEMADAPTER_H
 
-#include <libmeegosyncml/SyncItem.h>
+#include <buteosyncml/SyncItem.h>
 
 namespace Buteo {
     class StorageItem;

--- a/syncmlcommon/SimpleItem.h
+++ b/syncmlcommon/SimpleItem.h
@@ -24,7 +24,7 @@
 #ifndef SIMPLEITEM_H
 #define SIMPLEITEM_H
 
-#include <libsyncpluginmgr/StorageItem.h>
+#include <buteosyncfw/StorageItem.h>
 
 /*! \brief Simple implementation for storage item
  *

--- a/syncmlcommon/StorageAdapter.cpp
+++ b/syncmlcommon/StorageAdapter.cpp
@@ -23,8 +23,8 @@
 
 #include "StorageAdapter.h"
 
-#include <libsyncpluginmgr/StoragePlugin.h>
-#include <libsyncpluginmgr/StorageItem.h>
+#include <buteosyncfw/StoragePlugin.h>
+#include <buteosyncfw/StorageItem.h>
 
 #include "SyncMLCommon.h"
 #include "ItemAdapter.h"

--- a/syncmlcommon/StorageAdapter.h
+++ b/syncmlcommon/StorageAdapter.h
@@ -27,10 +27,10 @@
 #include <QMap>
 #include <QVector>
 
-#include <libsyncpluginmgr/StoragePlugin.h>
-#include <libmeegosyncml/StoragePlugin.h>
-#include <libmeegosyncml/DataStore.h>
-#include <libmeegosyncml/SyncItemKey.h>
+#include <buteosyncfw/StoragePlugin.h>
+#include <buteosyncml/StoragePlugin.h>
+#include <buteosyncml/DataStore.h>
+#include <buteosyncml/SyncItemKey.h>
 
 #include "ItemIdMapper.h"
 

--- a/syncmlcommon/SyncMLConfig.cpp
+++ b/syncmlcommon/SyncMLConfig.cpp
@@ -26,9 +26,10 @@
 #include <QDir>
 
 #include <LogMacros.h>
+#include "SyncCommonDefs.h"
 
-const QString XMLDIR( "/etc/sync/xml/");
-const QString DBDIR( "/.sync/sync-app/" );
+const QString XMLDIR( "/etc/buteo/xml/");
+const QString DBDIR( "/sync-app/" );
 const QString DEVINFO_FILE_NAME("devInfo.xml");
 
 SyncMLConfig::SyncMLConfig()
@@ -44,17 +45,14 @@ SyncMLConfig::~SyncMLConfig()
 
 QString SyncMLConfig::getDatabasePath()
 {
-	FUNCTION_CALL_TRACE;
+    FUNCTION_CALL_TRACE;
 
-	QString home = QDir::homePath();
-	QString path = home + DBDIR;
+    QString path = Sync::syncCacheDir() + DBDIR;
 
-	QDir dir( path );
-	if( !dir.exists() ) {
-		dir.mkpath( path );
-	}
+    QDir dir( path );
+    dir.mkpath( path );
 
-	return path;
+    return path;
 
 }
 

--- a/syncmlcommon/SyncMLStorageProvider.cpp
+++ b/syncmlcommon/SyncMLStorageProvider.cpp
@@ -23,14 +23,14 @@
 
 #include "SyncMLStorageProvider.h"
 
-#include <libsyncprofile/Profile.h>
-#include <libsyncprofile/ProfileEngineDefs.h>
+#include <buteosyncfw/Profile.h>
+#include <buteosyncfw/ProfileEngineDefs.h>
 
-#include <libsyncpluginmgr/PluginCbInterface.h>
-#include <libsyncpluginmgr/StoragePlugin.h>
+#include <buteosyncfw/PluginCbInterface.h>
+#include <buteosyncfw/StoragePlugin.h>
 
-#include <libmeegosyncml/StoragePlugin.h>
-#include <libmeegosyncml/SessionHandler.h>
+#include <buteosyncml/StoragePlugin.h>
+#include <buteosyncml/SessionHandler.h>
 
 #include "SyncMLCommon.h"
 #include "StorageAdapter.h"

--- a/syncmlcommon/SyncMLStorageProvider.h
+++ b/syncmlcommon/SyncMLStorageProvider.h
@@ -24,7 +24,7 @@
 #ifndef SYNCMLSTORAGEPROVIDER_H
 #define SYNCMLSTORAGEPROVIDER_H
 
-#include <libmeegosyncml/StorageProvider.h>
+#include <buteosyncml/StorageProvider.h>
 
 namespace Buteo {
     class Profile;

--- a/syncmlcommon/syncmlcommon.pro
+++ b/syncmlcommon/syncmlcommon.pro
@@ -1,16 +1,17 @@
 TEMPLATE = lib
 TARGET = syncmlcommon
 DEPENDPATH += .
-INCLUDEPATH += . \
-               /usr/include/libsynccommon
-               
-LIBS += -lsyncpluginmgr -lmeegosyncml -lsyncprofile
 
-CONFIG += create_pc create_prl mobility
+CONFIG += link_pkgconfig create_pc create_prl mobility
+PKGCONFIG = buteosyncfw buteosyncml
 
 MOBILITY += systeminfo
 QT += sql xml
 QT -= gui
+
+VER_MAJ = 1
+VER_MIN = 0
+VER_PAT = 0
 
 #input
 HEADERS += ItemAdapter.h \

--- a/syncmlcommon/unittest/SyncMLConfigTest.cpp
+++ b/syncmlcommon/unittest/SyncMLConfigTest.cpp
@@ -36,11 +36,11 @@ void SyncMLConfigTest::cleanupTestCase()
 void SyncMLConfigTest::testXmldatabasePath()
 {
 	//testing the function getDatabasePath()
-	QString DBDIR1 = "/.sync/sync-app/";
+	QString DBDIR1 = Sync::syncDir();
 	QString home = QDir::homePath();
 	QString path = home + DBDIR1;
 	QVERIFY(iConfig->getDatabasePath().contains(path));
 	
 	//testing the function getXmlDataPath()
-	QVERIFY(iConfig->getXmlDataPath().contains("/etc/sync/xml/"));
+	QVERIFY(iConfig->getXmlDataPath().contains("/etc/buteo/xml/"));
 }

--- a/syncmlcommon/unittest/SyncMLStorageProviderTest.cpp
+++ b/syncmlcommon/unittest/SyncMLStorageProviderTest.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "SyncMLStorageProviderTest.h"
-#include <libmeegosyncml/StoragePlugin.h>
+#include <buteosyncml/StoragePlugin.h>
 #include <QDomDocument>
 
 #include <QtTest/QtTest>
@@ -117,7 +117,7 @@ StoragePlugin* TempPluginCbInterface ::createStorage(const QString& aStorage)
     QString path = dir.absolutePath();
 
     // need to replace the library path with dummy library path
-    if (dir.cd("/usr/lib/sync"))
+    if (dir.cd("/usr/lib"))
     {
         path = dir.absolutePath();
     }

--- a/syncmlcommon/unittest/unittest.pro
+++ b/syncmlcommon/unittest/unittest.pro
@@ -72,7 +72,8 @@ SOURCES += main.cpp \
 
 QT += testlib sql xml
 QT -= gui
-CONFIG += qtestlib
+CONFIG += link_pkgconfig qtestlib
+PKGCONFIG = buteosyncfw
 
 QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno
 QMAKE_CXXFLAGS += -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
files creation to ~/.cache. Added a work around to re-initialize
QContactManager at the time of which, without which msyncd just exits
Fixed indentation. Removed the hack to create a new contacts manager

Made the necessary changes to be in sync with the directory and library
structure changes in buteo-syncfw
Fixed bug in the copying of /etc/buteo/sync files
Updated the .pro files to use pkgconfig of buteosyncfw rather than
hardcoding the library and include paths

Updated the xml files of the plug-ins to reflect the changes done
to the profile xmls in buteosyncfw. The service and the sync profile
xml files are merged into a single sync xml file.
To being with, change is done only to memotoo.xml. Once proper testing
for this is complete, change would be done to other profiles too
Modified the location of the buteo plugins directory to /usr/lib/buteo-plugins
Fixed issues with include paths

Signed-off-by: Sateesh Kavuri sateesh@mobilitas.co
