### PR TITLE
Increased size of PHOTO and SOUND fields in CtCaps for Contacts

### DIFF
--- a/storageplugins/hcontacts/xml/CTCaps_contacts_12.xml
+++ b/storageplugins/hcontacts/xml/CTCaps_contacts_12.xml
@@ -103,7 +103,7 @@
     <Property>
       <PropName>PHOTO</PropName>
       <DataType />
-      <MaxSize>256</MaxSize>
+      <MaxSize>160000</MaxSize>
     </Property>
     <Property>
       <PropName>BDAY</PropName>
@@ -113,7 +113,7 @@
     <Property>
       <PropName>SOUND</PropName>
       <DataType />
-      <MaxSize>256</MaxSize>
+      <MaxSize>160000</MaxSize>
     </Property>
     <Property>
       <PropName>X-ASSISTANT</PropName>


### PR DESCRIPTION
If syncml-ds-tool is used with SyncML ver 1.2, then increasing the PHOTO
(and SOUND) clip would allow the tool to accept the contact vcard in a
single message. The tool can be used with 1.2 version by providing the
option '--version 1.2'

Signed-off-by: Sateesh Kavuri sateesh.kavuri@gmail.com
