### PR TITLE
Patch to create a bluetooth profile for device-device sync

### DIFF
--- a/serverplugins/syncmlserver/BTConnection.cpp
+++ b/serverplugins/syncmlserver/BTConnection.cpp
@@ -48,6 +48,15 @@ struct sockaddr_rc {
     uint8_t         rc_channel;
 };
 
+static QString
+btAddrInHex (const btbdaddr_t* ba, char* str)
+{
+    sprintf(str, "%2.2X:%2.2X:%2.2X:%2.2X:%2.2X:%2.2X",
+            ba->b[5], ba->b[4], ba->b[3], ba->b[2], ba->b[1], ba->b[0]);
+    QString btAddr (str);
+    return btAddr.toUpper ();
+}
+
 BTConnection::BTConnection() :
     mServerFd (-1), mClientFd (-1), mPeerSocket (-1), mMutex (QMutex::Recursive),
     mDisconnected (true), mClientServiceRecordId (-1), mServerServiceRecordId (-1),
@@ -328,7 +337,9 @@ BTConnection::handleIncomingBTConnection (int fd)
         LOG_DEBUG ("Error in accept:" << strerror (errno));
     } else
     {
-        emit btConnected (mPeerSocket);
+        char buf[128] = { 0 };
+        QString btAddr = btAddrInHex (&remote.rc_bdaddr, buf);
+        emit btConnected (mPeerSocket, btAddr);
     }
     
     // Disable event notifier

--- a/serverplugins/syncmlserver/BTConnection.h
+++ b/serverplugins/syncmlserver/BTConnection.h
@@ -72,7 +72,7 @@ public:
 
 signals:
 
-    void btConnected (int fd);
+    void btConnected (int fd, QString btAddr);
 
 protected slots:
     

--- a/serverplugins/syncmlserver/SyncMLServer.cpp
+++ b/serverplugins/syncmlserver/SyncMLServer.cpp
@@ -319,8 +319,8 @@ SyncMLServer::createBTTransport ()
     LOG_DEBUG ("Creating new BT connection");
     bool btInitRes = mBTConnection.init ();
     
-    QObject::connect (&mBTConnection, SIGNAL (btConnected (int)),
-                      this, SLOT (handleBTConnected (int)));
+    QObject::connect (&mBTConnection, SIGNAL (btConnected (int, QString)),
+                      this, SLOT (handleBTConnected (int, QString)));
     
     return btInitRes;
 }
@@ -340,8 +340,8 @@ SyncMLServer::closeBTTransport ()
 {
     FUNCTION_CALL_TRACE;
     
-    QObject::disconnect (&mBTConnection, SIGNAL (btConnected (int)),
-                         this, SLOT (handleBTConnected (int)));
+    QObject::disconnect (&mBTConnection, SIGNAL (btConnected (int, QString)),
+                         this, SLOT (handleBTConnected (int, QString)));
     mBTConnection.uninit ();
 }
 
@@ -376,12 +376,12 @@ SyncMLServer::handleUSBConnected (int fd)
     if (!mAgent)
     {
         mConnectionType = Sync::CONNECTIVITY_USB;
-        startNewSession ();
+        startNewSession ("USB");
     }
 }
 
 void
-SyncMLServer::handleBTConnected (int fd)
+SyncMLServer::handleBTConnected (int fd, QString btAddr)
 {
     FUNCTION_CALL_TRACE;
     Q_UNUSED (fd);
@@ -411,12 +411,12 @@ SyncMLServer::handleBTConnected (int fd)
     if (!mAgent)
     {
         mConnectionType = Sync::CONNECTIVITY_BT;
-        startNewSession ();
+        startNewSession (btAddr);
     }
 }
 
 bool
-SyncMLServer::startNewSession ()
+SyncMLServer::startNewSession (QString address)
 {
     FUNCTION_CALL_TRACE;
 
@@ -436,7 +436,7 @@ SyncMLServer::startNewSession ()
 
     if (mAgent->listen (*mConfig))
     {
-        LOG_DEBUG ("New session started");
+        emit newSession (address);
         return true;
     } else
     {

--- a/serverplugins/syncmlserver/SyncMLServer.h
+++ b/serverplugins/syncmlserver/SyncMLServer.h
@@ -100,7 +100,7 @@ protected slots:
 
     void handleUSBConnected (int fd);
 
-    void handleBTConnected (int fd);
+    void handleBTConnected (int fd, QString btAddr);
 
     void handleSyncFinished (DataSync::SyncState state);
 
@@ -132,7 +132,7 @@ private:
     
     bool createBTTransport ();
 
-    bool startNewSession ();
+    bool startNewSession (QString address);
 
     void generateResults (bool success);
 

--- a/serverplugins/syncmlserver/syncmlserver.pro
+++ b/serverplugins/syncmlserver/syncmlserver.pro
@@ -57,11 +57,14 @@ QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno $(OBJECTS_DIR)/*.gcov
 sync.path = /etc/buteo/profiles/server
 sync.files = xml/syncml.xml
 
+template.path = /etc/buteo/profiles/sync
+template.files = xml/bt_template.xml
+
 btsrs.path = /etc/buteo/plugins/syncmlserver
 btsrs.files = xml/syncml_server_sdp_record.xml xml/syncml_client_sdp_record.xml
 
 #installs
-INSTALLS += target sync btsrs
+INSTALLS += target sync btsrs template
 
 OTHER_FILES += xml/syncml_server_sdp_record.xml \
                 xml/syncml_client_sdp_record.xml

--- a/serverplugins/syncmlserver/xml/bt_template.xml
+++ b/serverplugins/syncmlserver/xml/bt_template.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<profile name="bt_template" type="sync">
+
+    <key name="enabled" value="false"/>
+    <key name="hidden" value="true"/>
+    <key name="remote_id" value="/"/>
+    <!-- For purpose of localization in UI -->
+    <key name="displayname" value="qtn_sync_dest_name_device_default"/>
+
+    <profile type="service" name="bt">
+    </profile>
+
+    <profile name="syncml" type="client" >
+        <key name="Sync Direction" value="two-way" />
+    </profile>
+
+    <profile name="hcontacts" type="storage">
+	<key name="enabled" value="true"/>
+    </profile>
+    
+    <profile name="hcalendar" type="storage">
+        <key name="enabled" value="true"/>
+	<key name="Notebook Name" value="Personal"/>
+    </profile>
+
+     <profile name="hsms" type="storage">
+         <key name="enabled" value="false"/>
+    </profile>	    
+    
+    <profile name="hnotes" type="storage">
+	 <key name="enabled" value="true"/>
+     </profile>
+</profile>


### PR DESCRIPTION
This patch enables the creation of a profile for bluetooth based
device-device sync. If the target is a PC, then the profile name would
be PC-SYNC.xml. Incase of a device, the profile can be fetched with the
call: ProfileManager.getSyncProfilesByData(QString::null, Profile::TYPE_SYNC,
KEY_BT_ADDRESS, "B4:EE:D4:F6:19:E7");
Added bt_template.xml as the template XML file for profile generation

Signed-off-by: Sateesh Kavuri sateesh.kavuri@gmail.com
