### PR TITLE
[buteo-sync-plugins] Install default service profile XML files.

### DIFF
--- a/clientplugins/syncmlclient/syncmlclient.pro
+++ b/clientplugins/syncmlclient/syncmlclient.pro
@@ -56,8 +56,8 @@ client.files = xml/syncml.xml
 sync.path = /etc/buteo/profiles/sync
 sync.files = xml/sync/*
 
-#service.path = /etc/buteo/profiles/service
-#service.files = xml/service/*
+service.path = /etc/buteo/profiles/service
+service.files = xml/service/*
 
 storage.path = /etc/buteo/profiles/storage
 storage.files = xml/storage/*

--- a/rpm/buteo-sync-plugins-qt5.spec
+++ b/rpm/buteo-sync-plugins-qt5.spec
@@ -36,6 +36,7 @@ BuildRequires: doxygen
 %config %{_sysconfdir}/buteo/profiles/server/*.xml
 %config %{_sysconfdir}/buteo/profiles/client/*.xml
 %config %{_sysconfdir}/buteo/profiles/storage/*.xml
+%config %{_sysconfdir}/buteo/profiles/service/*.xml
 %config %{_sysconfdir}/buteo/profiles/sync/bt_template.xml
 %config %{_sysconfdir}/buteo/plugins/syncmlserver/*.xml
 %{_libdir}/buteo-plugins-qt5/*.so


### PR DESCRIPTION
If these are not installed, Bluetooth SyncML client requests cannot be
made as the default bt.xml service file cannot be located by msyncd.
