### PR TITLE
[buteo-syncml-plugins] Don't duplicate modified contact ids.

### DIFF
--- a/storageplugins/hcontacts/ContactsBackend.cpp
+++ b/storageplugins/hcontacts/ContactsBackend.cpp
@@ -524,6 +524,7 @@ void ContactsBackend::getSpecifiedContactIds(const QContactChangeLogFilter::Even
     } // no else
 
     // Convert strIdList to aIdList (QContactId)
+    aIdList.clear();
     foreach (const QString &id, strIdList) {
         aIdList << QContactId::fromString (id);
     }


### PR DESCRIPTION
Before aIdList is populated with the modified contact ids, the list
must be cleared, else it will contain both the existing ids and the
newly added ids.

This patch allows fast syncs with modified contacts to be performed
successfully. Otherwise, this operation currently results in an error
because the number of returned contacts is always double the requested
amount, which causes SyncItemPrefetcher::prefetch() to cancel its
fetch operation.
