### PR TITLE
[buteo-sync-plugins] Retrieve contacts from non-privileged database.

### DIFF
--- a/storageplugins/hcontacts/ContactsBackend.h
+++ b/storageplugins/hcontacts/ContactsBackend.h
@@ -237,15 +237,6 @@ private: // functions
                                 const QDateTime &aTimeStamp,
                                 QList<QContactLocalId> &aIdList);
 
-    /*!
-     * \brief Constructs and returns the filter for accessing only contacts allowed to be synchronized
-     * Contacts not allowed to be synchronized are Instant messaging contacts and contacts with origin from other sync backends;
-     * those contacts have QContactSyncTarget::SyncTarget value different from address book or buteo sync clients.
-     * It is designed that buteo sync clients don't restrict access to contacts among themselves
-     * - value for QContactSyncTarget::SyncTarget written by this backend is "buteo".
-     */
-    QContactFilter getSyncTargetFilter() const;
-
 private: // data
 
     // if there is more than one Manager we need to have a list of Managers


### PR DESCRIPTION
This ensures we only export contacts that should be exportable to
external devices. The "local" syncTarget filter is no longer necessary
as using this database ensures we only export contacts that we should
export anyway.
