### PR TITLE
[buteo-sync-plugins] Fix build breakage

### DIFF
--- a/buteo-sync-plugins.pro
+++ b/buteo-sync-plugins.pro
@@ -11,6 +11,10 @@ clientplugins.subdir = clientplugins
 clientplugins.target = sub-clientplugins
 clientplugins.depends = sub-syncmlcommon
 
+serverplugins.subdir = serverplugins
+serverplugins.target = sub-serverplugins
+serverplugins.depends = sub-syncmlcommon
+
 storageplugins.subdir = storageplugins
 storageplugins.target = sub-storageplugins
 storageplugins.depends = sub-syncmlcommon
@@ -21,29 +25,19 @@ storagechangenotifierplugins.target = sub-storagechangenotifierplugins
 doc.subdir = doc
 doc.target = sub-doc
 
-serverplugins.subdir = serverplugins
-serverplugins.target = sub-serverplugins
-serverplugins.depends = sub-syncmlcommon
-
-serverplugins_syncmlserver.subdir = serverplugins/syncmlserver
-serverplugins_syncmlserver.target = sub-serverplugins_syncmlserver
-serverplugins_syncmlserver.depends = sub-syncmlcommon
-
 SUBDIRS += \
     syncmlcommon \
     utils \
     clientplugins \
+    serverplugins \
     storageplugins \
     storagechangenotifierplugins \
-    doc \
-    serverplugins \
-    serverplugins_syncmlserver
+    doc
 
 testdefinition.path = /opt/tests/buteo-sync-plugins/test-definition
 testdefinition.files = bin/tests.xml
 tests.path = /opt/tests/buteo-sync-plugins/
-tests.files =  \
-              bin/runstarget.sh
+tests.files = bin/runstarget.sh
 
 INSTALLS += tests testdefinition
 

--- a/clientplugins/clientplugins.pro
+++ b/clientplugins/clientplugins.pro
@@ -1,4 +1,2 @@
 TEMPLATE = subdirs
-
 SUBDIRS += syncmlclient
-

--- a/clientplugins/syncmlclient/syncmlclient.pro
+++ b/clientplugins/syncmlclient/syncmlclient.pro
@@ -19,12 +19,14 @@ HEADERS += SyncMLClient.h BTConnection.h
 SOURCES += SyncMLClient.cpp BTConnection.cpp
 
 PLUGIN_DLL {
+    message("building syncml-client as in-process plugin")
     TEMPLATE = lib
     CONFIG += plugin
     target.path = /usr/lib/buteo-plugins-qt5
 }
 
 PLUGIN_EXE {
+    message("building syncml-client as out-of-process plugin")
     TEMPLATE = app
     target.path = /usr/lib/buteo-plugins-qt5/oopp
 

--- a/serverplugins/syncmlserver/syncmlserver.pro
+++ b/serverplugins/syncmlserver/syncmlserver.pro
@@ -32,6 +32,7 @@ HEADERS += SyncMLServer.h\
 OTHER_FILES += xml/*
 
 PLUGIN_DLL {
+    message("building syncml-server as in-process plugin")
     TEMPLATE = lib
     CONFIG += plugin
     DEFINES += SYNCMLSERVER_LIBRARY
@@ -39,7 +40,9 @@ PLUGIN_DLL {
 }
 
 PLUGIN_EXE {
+    message("building syncml-server as out-of-process plugin")
     TEMPLATE = app
+    target.path = /usr/lib/buteo-plugins-qt5/oopp/
     DEFINES += "CLASSNAME=SyncMLServer"
     DEFINES += CLASSNAME_H=\\\"SyncMLServer.h\\\"
     DEFINES += GLIB_FD_WATCH
@@ -52,7 +55,6 @@ PLUGIN_EXE {
     HEADERS += $$INCLUDE_DIR/ButeoPluginIfaceAdaptor.h \
         $$INCLUDE_DIR/PluginCbImpl.h \
         $$INCLUDE_DIR/PluginServiceObj.h
-    target.path = /usr/lib/buteo-plugins-qt5/oopp/
 }
 
 sync.path = /etc/buteo/profiles/server


### PR DESCRIPTION
Don't attempt to build the syncml server twice and concurrently,
because this is silly and it can cause moc files to be regenerated
during a concurrent build, causing breakage.
