### PR TITLE
[buteo-sync-plugins] Enable calendar synchronization over Bluetooth. Contributes to MER#1222

### DIFF
--- a/serverplugins/syncmlserver/xml/syncml.xml
+++ b/serverplugins/syncmlserver/xml/syncml.xml
@@ -8,4 +8,12 @@
         <key name="enabled" value="true" />
         <key name="Local URI" value="./contacts" />
     </profile>
+
+    <profile name="hcalendar" type="storage" >
+        <key name="enabled" value="true" />
+        <key name="Local URI" value="./calendar" />
+        <key name="Target URI" value="./calendar" />
+        <key name="Calendar Format" value="vcalendar" />
+        <key name="Notebook Name" value="Personal" />
+    </profile>
 </profile>

--- a/storageplugins/hcalendar/CalendarBackend.h
+++ b/storageplugins/hcalendar/CalendarBackend.h
@@ -58,8 +58,7 @@ public:
     virtual ~CalendarBackend();
 
     //! \brief Initializes the CalendarBackend
-    // \param strNotebookName Name of the notebook to use
-    bool init( const QString& aNotebookName, const QString& aUid = "" );
+    bool init( const QString& aUid = QString() );
 
     //! \brief Uninitializes the storage
     bool uninit();

--- a/storageplugins/hcalendar/CalendarStorage.cpp
+++ b/storageplugins/hcalendar/CalendarStorage.cpp
@@ -69,21 +69,10 @@ bool CalendarStorage::init( const QMap<QString, QString>& aProperties )
 
     iProperties = aProperties;
 
-    // Use remote name (e.g. bt name) as notebook name.
-    if (iProperties.contains(Buteo::KEY_REMOTE_NAME)) {
-        LOG_DEBUG("Using remote name as notebook name");
-        iProperties[NOTEBOOKNAME] = iProperties.value(Buteo::KEY_REMOTE_NAME);
-    }
-    else if( iProperties.value( NOTEBOOKNAME ).isEmpty() ) {
-        LOG_WARNING( NOTEBOOKNAME << " property not found" <<
-                "for calendar storage, using default of" <<
-                DEFAULT_NOTEBOOK_NAME );
-        iProperties[NOTEBOOKNAME] = DEFAULT_NOTEBOOK_NAME;
-    }
-
-    LOG_DEBUG("Initializing calendar, notebook name:" <<  iProperties[NOTEBOOKNAME]); 
-
-    if( !iCalendar.init( iProperties[NOTEBOOKNAME], iProperties[Buteo::KEY_UUID] ) ) {
+    // Note: we don't use the KEY_UUID value, as msyncd just generates
+    // a random one on the fly - it doesn't actually correspond to any
+    // real notebook UID which exists on the device.
+    if( !iCalendar.init( ) ) {
         return false;
     }
 


### PR DESCRIPTION
This commit enables calendar sync over Bluetooth.
In order to do so, it does several things:

1) adds the hcalendar storage backend as a supported storage
backend for the syncml server plugin

2) modifies the calendar backend to access the appropriate
local device notebook

3) modifies the calendar storage plugin so that it now ignores
the (randomly generated) KEY_UUID value when requesting access
to the calendar backend.

Contributes to MER#1222
